### PR TITLE
Avoid xss in location input field

### DIFF
--- a/application/views/scripts/location.phtml
+++ b/application/views/scripts/location.phtml
@@ -6,7 +6,7 @@
     <input id="<?= $this->element->getName(); ?>"
            type="text"
            name="<?= $this->element->getName(); ?>"
-           value="<?= $this->element->getValue(); ?>"
+           value="<?= htmlspecialchars($this->element->getValue(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>"
         <?php if ($p = $this->element->getAttrib('placeholder')) {
             print 'placeholder="' . htmlspecialchars($p) . '"';
         } ?>/>


### PR DESCRIPTION
Injecting HTML code as the value of the input field exposes the field itself to a cross site scripting vulnerability.

refs #11 